### PR TITLE
Load dependencies only if not yet loaded

### DIFF
--- a/includes/class-amazonpolly.php
+++ b/includes/class-amazonpolly.php
@@ -159,7 +159,9 @@ class Amazonpolly {
 		/**
 		 * Load AWS PHP SDK
 		 */
-		require_once plugin_dir_path(dirname(__FILE__)) . 'vendor/autoload.php';
+		if ( ! class_exists( 'Aws\Sdk' ) ) {
+			require_once plugin_dir_path(dirname(__FILE__)) . 'vendor/autoload.php';
+		}
 
 		/**
 		 * The class responsible for custom helper functions


### PR DESCRIPTION
*Issue #38*

*Description of changes:*
Calls vendor autoload only if we don't already have the Aws\Sdk class available. Another plugin or theme may have already loaded Aws\Sdk and we don't want to load duplicate instances of it or its dependencies as that can lead to conflicts..

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
